### PR TITLE
[schedbench] Handle the delta=0 case in rps stats

### DIFF
--- a/schbench.c
+++ b/schbench.c
@@ -1634,7 +1634,7 @@ static void sleep_for_runtime(struct thread_data *message_threads_mem)
 			last_rps_calc = now;
 
 			if (!auto_rps || auto_rps_target_hit)
-				add_lat(&rps_stats, rps);
+				add_lat(&rps_stats, isfinite(rps) ? rps : 0);
 
 			delta = tvdelta(&last_calc, &now);
 			if (delta >= interval_usec) {


### PR DESCRIPTION
In case when delta is 0, rps will not be a proper number. Division by 0 in case of a float is not an error. 
But if we try to convert that to an int when passing to add_lat(), it will yell with: 
```
third-party/schbench/schbench.c:1584:25: runtime error: -nan is outside the range of representable values of type 'unsigned int'
    #0 0x2d5938 in main third-party/schbench/schbench.c:1584
    #1 0x7faf5f42c656 in __libc_start_call_main /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #2 0x7faf5f42c717 in __libc_start_main@GLIBC_2.2.5 /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../csu/libc-start.c:409:3
    #3 0x2cf290 in _start /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86_64/start.S:116
```