### PR TITLE
schbench: add support for s390 architecture

### DIFF
--- a/schbench.c
+++ b/schbench.c
@@ -1132,7 +1132,7 @@ unsigned long long read_sched_delay(pid_t tid)
 #define nop __asm__ __volatile__("rep;nop": : :"memory")
 #elif defined(__aarch64__)
 #define nop __asm__ __volatile__("yield" ::: "memory")
-#elif defined(__powerpc64__)
+#elif defined(__powerpc64__) || defined(__s390__)
 #define nop __asm__ __volatile__("nop": : :"memory")
 #else
 #error Unsupported architecture


### PR DESCRIPTION
Hi Chris I would like to merge this change to enable s390/IBM Z architecture compilation support.