### PR TITLE
schbench: Add option for choosing share of private working set

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ The size of our matrix for worker thread math.
 `-n, --operations <N>`: think time operations to perform (def: `5`)
 The number of times we'll loop on the matrix math in each request.
 
+`--split <PERCENT>`: percent of cache footprint that is private per thread (def: `all private`)
+Split the cache footprint between shared and private working sets. The percentage represents how much is private per thread, with the remainder shared across all threads. For example, `--split 30` means 30% private, 70% shared. When not specified, all data is private per thread (original behavior). Useful for testing scheduler behavior with both shared state (causing cache line bouncing) and thread-local data.
+
 `-s, --sleep-usec <USEC>`: time to sleep during each requests, in usec (def: `100`)
 
 `-A, --auto-rps <PERCENT>`: grow RPS until cpu utilization hits target (def: `none`)


### PR DESCRIPTION
Add a new --split option that allows splitting the cache footprint between shared and private working sets. This enables testing scheduler behavior when threads have both shared cache footprint (from a common data structure) and private working sets (per-thread data).

The --split parameter accepts a percentage (0-100) representing how much of the total cache footprint should be private per thread, with the remainder being shared across all threads. For example, --split 30 means:
- 30% of cache_footprint_kb is allocated per worker thread (private)
- 70% of cache_footprint_kb is shared by all threads (single allocation)

Operations are split proportionally: if the workload specifies 10 operations and --split 30, each thread performs 3 operations on its private data and 7 operations on the shared data.

This is useful for benchmarking realistic workloads where threads both access shared state (requiring synchronization and causing cache line bouncing) and process thread-local data.

When --split is not specified, the original behavior is preserved: all data is private per thread.